### PR TITLE
Update README license information to MIT License

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,4 +188,4 @@ For more information, see the [documentation](./docs/README.md).
 
 ## License
 
-UNLICENSED - Internal use only
+This project is licensed under the MIT License - see the [LICENSE](./LICENSE) file for details.


### PR DESCRIPTION
Fixes #4 

This PR updates the README to correctly reflect that the project is licensed under the MIT License, matching the LICENSE file that already exists in the repository.

Changes:
- Updated the license section at the bottom of the README from "UNLICENSED - Internal use only" to proper MIT license information
- Added a link to the LICENSE file for details

This change is important now that the repository is public to ensure users understand they can legally use, modify, and distribute the code under the MIT License terms.